### PR TITLE
Document Atlan DXR playbook in repo guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
   - `dxr-metadata-athena-pipeline/`: Terraform + Lambda under `terraform/` (Python in `terraform/lambda/`).
   - `glue-unstructured-dq-monitoring/`: Terraform helpers, Lambda, and Glue artefacts for Data Quality experiments.
   - `s3-etl-quarantine/`: Pulumi-driven S3 quarantine demo (Python lambda + uv tooling).
+  - `atlan-dxr-integration/`: Data X-Ray → Atlan metadata sync service (Python, pytest under `tests/`, Dockerised runtime).
   - Root config: `pytest.ini` (markers), `.env` (local vars, do not commit secrets).
 - Keep the root `README.md` aligned with this list of active subprojects whenever directories are added, removed, or renamed.
 
@@ -22,6 +23,7 @@
   - Root markers: `pytest -m unit`, `-m integration`, or `-m destructive`.
   - Email playbook: `cd scan-email-attachments && pytest -q`.
   - Purview: `cd purview-stream-endpoint && pytest -q`.
+  - Atlan ↔ DXR playbook: `cd atlan-dxr-integration && pytest -q` (integration tests stub external SDKs).
 
 ## Coding Style & Naming
 - Python: 4-space indent, `snake_case` for files/functions, `PascalCase` classes.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,14 @@ This repository currently includes the following playbooks:
 - **[`dxr-metadata-athena-pipeline`](./dxr-metadata-athena-pipeline/)**  
   Terraform-driven pipeline that lifts Data X-Ray's metadata plane into AWS Glue and exposes it through Athena so governance teams can run ad-hoc discovery and compliance queries. The [README](./dxr-metadata-athena-pipeline/README.md) breaks down deployment and query workflows.
 
-- **[`glue-unstructured-dq-monitoring`](./glue-unstructured-dq-monitoring/)**  
+- **[`glue-unstructured-dq-monitoring`](./glue-unstructured-dq-monitoring/)**
   Lambda, Glue, and Data Quality assets that score unstructured files using Data X-Ray labels and AWS Glue DQ rulesets, keeping data lakes clean before ETL jobs consume sensitive content. See the [README](./glue-unstructured-dq-monitoring/README.md) for setup and runbook commands.
 
-- **[`s3-etl-quarantine`](./s3-etl-quarantine/)**  
+- **[`s3-etl-quarantine`](./s3-etl-quarantine/)**
   Pulumi-managed guardrail that watches S3 staging zones, classifies files with Data X-Ray, and automatically quarantines risky payloads feeding unstructured ETL pipelines. The [README](./s3-etl-quarantine/README.md) covers prerequisites, deployment, and cleanup steps.
+
+- **[`atlan-dxr-integration`](./atlan-dxr-integration/)**
+  Containerised service that syncs Data X-Ray classifications into Atlan as `DataSet` assets using the official Python SDK. Review the [README](./atlan-dxr-integration/README.md) for configuration, runtime options, and deployment guidance.
 
 ## Getting Started
 

--- a/atlan-dxr-integration/.dockerignore
+++ b/atlan-dxr-integration/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.env
+.env.*
+.git
+.gitignore
+Dockerfile
+README.md

--- a/atlan-dxr-integration/.env.example
+++ b/atlan-dxr-integration/.env.example
@@ -1,0 +1,18 @@
+# Data X-Ray configuration
+DXR_BASE_URL=https://atlan.dataxray.io/api
+DXR_PAT=replace-me
+# Comma-separated classification types to ingest (leave blank for all)
+DXR_CLASSIFICATION_TYPES=LABEL,ANNOTATOR
+DXR_SAMPLE_FILE_LIMIT=5
+
+# Atlan configuration
+ATLAN_BASE_URL=https://ohalo-partner.atlan.com/
+ATLAN_API_TOKEN=replace-me
+ATLAN_CONNECTION_QUALIFIED_NAME=default/custom/atlan-dxr
+ATLAN_CONNECTION_NAME=atlan-dxr
+ATLAN_CONNECTOR_NAME=custom
+ATLAN_DATASET_PATH_PREFIX=dxr
+ATLAN_BATCH_SIZE=20
+
+# Logging configuration
+LOG_LEVEL=INFO

--- a/atlan-dxr-integration/Dockerfile
+++ b/atlan-dxr-integration/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY atlan_dxr_integration/ atlan_dxr_integration/
+COPY README.md README.md
+
+CMD ["python", "-m", "atlan_dxr_integration"]

--- a/atlan-dxr-integration/README.md
+++ b/atlan-dxr-integration/README.md
@@ -1,0 +1,83 @@
+# Atlan ↔ Data X-Ray integration
+
+This playbook provides a containerised service that ingests Data X-Ray (DXR) labels and
+publishes them to Atlan as `DataSet` assets. The service is inspired by the existing
+Purview integration but uses Atlan's Python SDK (`pyatlan`) to manage metadata directly
+through Atlan's APIs.
+
+## High-level flow
+
+1. Authenticate against DXR using a personal access token (PAT).
+2. Fetch all classification labels (DXR "labels") and stream file metadata.
+3. Aggregate the files under each label to produce dataset summaries.
+4. Upsert the resulting datasets into Atlan using the configured connection.
+
+Each dataset created in Atlan uses the following conventions:
+
+- **Qualified name**: `<connection-qualified-name>/<dataset-path-prefix>/<classification-id>`
+- **Connector metadata**: `connectionName` and `connectorName` come from configuration.
+- **Description**: DXR label description plus a generated summary with the file count and
+  a short sample of files.
+- **Source URL**: Backlink to the DXR search page for that label when available.
+
+## Getting started
+
+1. Copy `.env.example` to `.env` and populate it with valid credentials.
+2. Build and run the container:
+
+   ```bash
+   cd atlan-dxr-integration
+   docker build -t atlan-dxr-sync .
+   docker run --rm --env-file .env atlan-dxr-sync
+   ```
+
+   Alternatively, run the module directly with Python:
+
+   ```bash
+   pip install -r requirements.txt
+   python -m atlan_dxr_integration
+   ```
+
+3. The service logs progress and exits once the current batch has been synced.
+   Schedule the container (for example through Atlan's embedded runtime, cron, or a
+   workflow orchestrator) to refresh datasets periodically.
+
+## Configuration
+
+Environment variables (see `.env.example`):
+
+| Variable | Description |
+|----------|-------------|
+| `DXR_BASE_URL` | Base URL for Data X-Ray's API (`/api` suffix included). |
+| `DXR_PAT` | Data X-Ray personal access token. |
+| `DXR_CLASSIFICATION_TYPES` | Optional comma-separated whitelist of DXR classification `type` values to ingest. Leave blank to ingest everything. |
+| `DXR_SAMPLE_FILE_LIMIT` | Number of sample files to include in dataset summaries. |
+| `ATLAN_BASE_URL` | Base URL for Atlan. |
+| `ATLAN_API_TOKEN` | Atlan API token. |
+| `ATLAN_CONNECTION_QUALIFIED_NAME` | Qualified name of the Atlan connection that owns the datasets. |
+| `ATLAN_CONNECTION_NAME` | Human-readable connection name for the datasets. |
+| `ATLAN_CONNECTOR_NAME` | Connector name string to persist on datasets (for example `custom`). |
+| `ATLAN_DATASET_PATH_PREFIX` | Path suffix appended to the connection qualified name when generating dataset qualified names. |
+| `ATLAN_BATCH_SIZE` | Maximum number of datasets to upsert in a single API call. |
+| `LOG_LEVEL` | Logging verbosity (`INFO`, `DEBUG`, ...). |
+
+## Implementation notes
+
+- `DXR` interactions rely on the documented `/api/vbeta/classifications` and
+  `/api/vbeta/files` endpoints.
+- Metadata is written to Atlan via `pyatlan`'s synchronous client (`AtlanClient.asset.save`).
+- The module is idempotent: rerunning the service overwrites datasets with the same
+  qualified name.
+- Connection management is out of scope — ensure the configured connection already exists
+  and grants the API token permission to create assets.
+
+## Development
+
+Run unit tests from the repository root:
+
+```bash
+pytest atlan-dxr-integration/tests -q
+```
+
+Feel free to extend the dataset transformer to attach additional metadata, lineage, or
+custom metadata once the relevant Atlan objects are defined.

--- a/atlan-dxr-integration/atlan_dxr_integration/__init__.py
+++ b/atlan-dxr-integration/atlan_dxr_integration/__init__.py
@@ -1,0 +1,13 @@
+"""Atlan ↔ Data X-Ray integration package."""
+
+from __future__ import annotations
+
+def run() -> None:
+    """Run the DXR → Atlan sync once."""
+
+    from .pipeline import run as _run
+
+    _run()
+
+
+__all__ = ["run"]

--- a/atlan-dxr-integration/atlan_dxr_integration/__main__.py
+++ b/atlan-dxr-integration/atlan_dxr_integration/__main__.py
@@ -1,0 +1,6 @@
+"""Command-line entrypoint for running the DXR → Atlan sync."""
+
+from .pipeline import run
+
+if __name__ == "__main__":
+    run()

--- a/atlan-dxr-integration/atlan_dxr_integration/atlan_uploader.py
+++ b/atlan-dxr-integration/atlan_dxr_integration/atlan_uploader.py
@@ -1,0 +1,67 @@
+"""Utilities for writing dataset records into Atlan."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List
+
+from pyatlan.client.atlan import AtlanClient
+from pyatlan.errors import AtlanError
+from pyatlan.model.assets.data_set import DataSet
+
+from .config import Config
+from .dataset_builder import DatasetRecord
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AtlanUploader:
+    """Wrapper around Atlan's Asset API for upserting datasets."""
+
+    def __init__(self, config: Config) -> None:
+        self._config = config
+        self._client = AtlanClient(
+            base_url=config.atlan_base_url,
+            api_key=config.atlan_api_token,
+        )
+
+    def upsert(self, records: Iterable[DatasetRecord]) -> None:
+        batch: List[DataSet] = []
+        for record in records:
+            dataset = self._build_dataset(record)
+            batch.append(dataset)
+            if len(batch) >= self._config.atlan_batch_size:
+                self._save_batch(batch)
+                batch = []
+        if batch:
+            self._save_batch(batch)
+
+    def _build_dataset(self, record: DatasetRecord) -> DataSet:
+        qualified_name = f"{self._config.qualified_name_prefix}/{record.identifier}"
+        attributes = DataSet.Attributes(
+            qualified_name=qualified_name,
+            name=record.name,
+            description=record.classification.description,
+            user_description=record.description,
+            connection_name=self._config.atlan_connection_name,
+            connection_qualified_name=self._config.atlan_connection_qualified_name,
+            connector_name=self._config.atlan_connector_name,
+            source_url=record.source_url,
+        )
+        dataset = DataSet(attributes=attributes)
+        return dataset
+
+    def _save_batch(self, batch: List[DataSet]) -> None:
+        try:
+            response = self._client.asset.save(batch)
+            LOGGER.info(
+                "Upserted %d datasets into Atlan (request id: %s)",
+                len(batch),
+                getattr(response, "request_id", "unknown"),
+            )
+        except AtlanError as exc:
+            LOGGER.error("Failed to upsert datasets into Atlan: %s", exc)
+            raise
+
+
+__all__ = ["AtlanUploader"]

--- a/atlan-dxr-integration/atlan_dxr_integration/config.py
+++ b/atlan-dxr-integration/atlan_dxr_integration/config.py
@@ -1,0 +1,111 @@
+"""Configuration handling for the DXR → Atlan integration."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional, Set
+
+from dotenv import load_dotenv
+
+
+@dataclass
+class Config:
+    """Runtime configuration loaded from environment variables."""
+
+    dxr_base_url: str
+    dxr_pat: str
+    dxr_classification_types: Optional[Set[str]]
+    dxr_sample_file_limit: int
+
+    atlan_base_url: str
+    atlan_api_token: str
+    atlan_connection_qualified_name: str
+    atlan_connection_name: str
+    atlan_connector_name: str
+    atlan_dataset_path_prefix: str
+    atlan_batch_size: int
+
+    log_level: str
+
+    @property
+    def qualified_name_prefix(self) -> str:
+        """Prefix used when generating dataset qualified names."""
+
+        suffix = self.atlan_dataset_path_prefix.strip("/")
+        if suffix:
+            return f"{self.atlan_connection_qualified_name.rstrip('/')}/{suffix}"
+        return self.atlan_connection_qualified_name.rstrip("/")
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        """Build configuration from environment variables."""
+
+        load_dotenv()
+
+        missing = [
+            name
+            for name in (
+                "DXR_BASE_URL",
+                "DXR_PAT",
+                "ATLAN_BASE_URL",
+                "ATLAN_API_TOKEN",
+                "ATLAN_CONNECTION_QUALIFIED_NAME",
+                "ATLAN_CONNECTION_NAME",
+                "ATLAN_CONNECTOR_NAME",
+            )
+            if not os.getenv(name)
+        ]
+        if missing:
+            raise ValueError(
+                "Missing required environment variables: " + ", ".join(missing)
+            )
+
+        classification_types = _parse_csv(os.getenv("DXR_CLASSIFICATION_TYPES"))
+        batch_size = _parse_int(os.getenv("ATLAN_BATCH_SIZE"), default=20, minimum=1)
+        sample_file_limit = _parse_int(
+            os.getenv("DXR_SAMPLE_FILE_LIMIT"), default=5, minimum=0
+        )
+
+        return cls(
+            dxr_base_url=_strip_trailing_slash(os.environ["DXR_BASE_URL"]),
+            dxr_pat=os.environ["DXR_PAT"],
+            dxr_classification_types=classification_types,
+            dxr_sample_file_limit=sample_file_limit,
+            atlan_base_url=_strip_trailing_slash(os.environ["ATLAN_BASE_URL"]),
+            atlan_api_token=os.environ["ATLAN_API_TOKEN"],
+            atlan_connection_qualified_name=os.environ[
+                "ATLAN_CONNECTION_QUALIFIED_NAME"
+            ],
+            atlan_connection_name=os.environ["ATLAN_CONNECTION_NAME"],
+            atlan_connector_name=os.environ["ATLAN_CONNECTOR_NAME"],
+            atlan_dataset_path_prefix=os.getenv("ATLAN_DATASET_PATH_PREFIX", "dxr"),
+            atlan_batch_size=batch_size,
+            log_level=os.getenv("LOG_LEVEL", "INFO"),
+        )
+
+
+def _parse_csv(raw: Optional[str]) -> Optional[Set[str]]:
+    if not raw:
+        return None
+    items = {value.strip().upper() for value in raw.split(",") if value.strip()}
+    return items or None
+
+
+def _parse_int(raw: Optional[str], *, default: int, minimum: int) -> int:
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Invalid integer value: {raw!r}") from exc
+    if value < minimum:
+        raise ValueError(f"Value must be >= {minimum}: {value}")
+    return value
+
+
+def _strip_trailing_slash(value: str) -> str:
+    return value.rstrip("/")
+
+
+__all__ = ["Config"]

--- a/atlan-dxr-integration/atlan_dxr_integration/dataset_builder.py
+++ b/atlan-dxr-integration/atlan_dxr_integration/dataset_builder.py
@@ -1,0 +1,177 @@
+"""Transformation utilities for turning DXR metadata into Atlan-ready records."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+from urllib.parse import urljoin
+
+from .dxr_client import Classification
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class SampleFile:
+    """Simplified representation of a DXR file used in dataset summaries."""
+
+    identifier: Optional[str]
+    name: Optional[str]
+    path: Optional[str]
+    link: Optional[str]
+
+    def render(self) -> str:
+        parts: List[str] = []
+        if self.name:
+            parts.append(self.name)
+        elif self.identifier:
+            parts.append(self.identifier)
+        if self.path and self.path not in parts:
+            parts.append(self.path)
+        return " – ".join(parts) if parts else (self.identifier or "Unknown file")
+
+
+@dataclass
+class DatasetRecord:
+    """Aggregated dataset representation ready for ingestion into Atlan."""
+
+    classification: Classification
+    file_count: int
+    sample_files: List[SampleFile] = field(default_factory=list)
+    description: Optional[str] = None
+    source_url: Optional[str] = None
+
+    @property
+    def identifier(self) -> str:
+        return self.classification.identifier
+
+    @property
+    def name(self) -> str:
+        return self.classification.name
+
+    @property
+    def classification_type(self) -> Optional[str]:
+        return self.classification.type
+
+    @property
+    def classification_subtype(self) -> Optional[str]:
+        return self.classification.subtype
+
+
+class DatasetBuilder:
+    """Build dataset records from DXR classifications and files."""
+
+    def __init__(
+        self,
+        classifications: Iterable[Classification],
+        *,
+        allowed_types: Optional[Iterable[str]] = None,
+        sample_file_limit: int = 5,
+        dxr_base_url: Optional[str] = None,
+    ) -> None:
+        self._records: Dict[str, DatasetRecord] = {}
+        self._allowed_types = {t.upper() for t in allowed_types} if allowed_types else None
+        self._sample_file_limit = sample_file_limit
+        self._dxr_base_url = _normalise_base_url(dxr_base_url) if dxr_base_url else None
+
+        for classification in classifications:
+            if self._allowed_types and (
+                (classification.type or "").upper() not in self._allowed_types
+            ):
+                LOGGER.debug(
+                    "Skipping classification %s due to filtered type %s",
+                    classification.identifier,
+                    classification.type,
+                )
+                continue
+            self._records[classification.identifier] = DatasetRecord(
+                classification=classification,
+                file_count=0,
+                source_url=self._build_source_url(classification),
+            )
+
+    def consume_file(self, payload: Dict[str, object]) -> None:
+        """Add a DXR file payload into the aggregation."""
+
+        labels = _extract_labels(payload)
+        if not labels:
+            return
+
+        for label in labels:
+            record = self._records.get(label)
+            if not record:
+                continue
+            record.file_count += 1
+            if len(record.sample_files) < self._sample_file_limit:
+                record.sample_files.append(
+                    SampleFile(
+                        identifier=_safe_str(payload.get("id")),
+                        name=_safe_str(payload.get("name") or payload.get("filename")),
+                        path=_safe_str(payload.get("path") or payload.get("filepath")),
+                        link=_safe_str(payload.get("link")),
+                    )
+                )
+
+    def build(self) -> List[DatasetRecord]:
+        """Generate final dataset records with descriptions."""
+
+        for record in self._records.values():
+            record.description = self._build_description(record)
+        return list(self._records.values())
+
+    def _build_source_url(self, classification: Classification) -> Optional[str]:
+        path = classification.search_link or classification.link
+        if not path or not self._dxr_base_url:
+            return path
+        return urljoin(self._dxr_base_url + "/", path.lstrip("/"))
+
+    def _build_description(self, record: DatasetRecord) -> Optional[str]:
+        description_parts: List[str] = []
+        if record.classification.description:
+            description_parts.append(record.classification.description)
+        description_parts.append(f"DXR dataset contains {record.file_count} file(s).")
+        if record.sample_files:
+            bullet_list = "\n".join(f"- {sample.render()}" for sample in record.sample_files)
+            description_parts.append("Sample files:\n" + bullet_list)
+        return "\n\n".join(description_parts)
+
+
+def _extract_labels(payload: Dict[str, object]) -> List[str]:
+    raw = payload.get("labels") or payload.get("classifications")
+    if not raw:
+        return []
+    if isinstance(raw, list):
+        identifiers = []
+        for item in raw:
+            if isinstance(item, dict):
+                identifier = item.get("id") or item.get("classificationId")
+                if identifier:
+                    identifiers.append(str(identifier))
+            elif isinstance(item, str):
+                identifiers.append(item)
+        return identifiers
+    if isinstance(raw, dict):
+        identifiers = []
+        for key in ("id", "classificationId"):
+            if key in raw:
+                identifiers.append(str(raw[key]))
+        return identifiers
+    return []
+
+
+def _safe_str(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _normalise_base_url(base_url: str) -> str:
+    cleaned = base_url.rstrip("/")
+    if cleaned.endswith("/api"):
+        cleaned = cleaned[: -len("/api")]
+    return cleaned
+
+
+__all__ = ["DatasetBuilder", "DatasetRecord", "SampleFile"]

--- a/atlan-dxr-integration/atlan_dxr_integration/dxr_client.py
+++ b/atlan-dxr-integration/atlan_dxr_integration/dxr_client.py
@@ -1,0 +1,113 @@
+"""Client for interacting with the Data X-Ray API."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Dict, Generator, List, Optional
+from urllib.parse import urljoin
+
+import requests
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Classification:
+    """Representation of a DXR classification (label)."""
+
+    identifier: str
+    name: str
+    type: Optional[str]
+    subtype: Optional[str]
+    description: Optional[str]
+    link: Optional[str]
+    search_link: Optional[str]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "Classification":
+        identifier = str(data.get("id")) if data.get("id") is not None else None
+        if not identifier:
+            raise ValueError("Classification payload missing 'id'.")
+        return cls(
+            identifier=identifier,
+            name=str(data.get("name") or identifier),
+            type=_safe_upper(data.get("type")),
+            subtype=_safe_upper(data.get("subtype")),
+            description=_safe_str(data.get("description")),
+            link=_safe_str(data.get("link")),
+            search_link=_safe_str(data.get("searchLink")),
+        )
+
+
+class DXRClient:
+    """Thin wrapper around DXR's HTTP API."""
+
+    def __init__(self, base_url: str, pat_token: str, *, timeout: int = 60) -> None:
+        self._base_url = base_url.rstrip("/") + "/"
+        self._timeout = timeout
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Authorization": f"Bearer {pat_token}",
+                "Accept": "application/json",
+            }
+        )
+
+    def close(self) -> None:
+        self._session.close()
+
+    def __enter__(self) -> "DXRClient":  # pragma: no cover - context manager glue
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - context manager glue
+        self.close()
+
+    def fetch_classifications(self) -> List[Classification]:
+        """Retrieve all classifications (labels) from DXR."""
+
+        url = urljoin(self._base_url, "vbeta/classifications")
+        LOGGER.debug("Fetching classifications from %s", url)
+        response = self._session.get(url, timeout=self._timeout)
+        response.raise_for_status()
+        payload = response.json()
+        items = payload.get("data", []) if isinstance(payload, dict) else []
+        classifications = []
+        for item in items:
+            try:
+                classifications.append(Classification.from_dict(item))
+            except ValueError as exc:
+                LOGGER.warning("Skipping malformed classification payload: %s", exc)
+        LOGGER.info("Fetched %d classifications from DXR", len(classifications))
+        return classifications
+
+    def stream_files(self) -> Generator[Dict[str, object], None, None]:
+        """Stream file metadata as dictionaries from DXR."""
+
+        url = urljoin(self._base_url, "vbeta/files")
+        LOGGER.debug("Streaming files from %s", url)
+        with self._session.get(url, stream=True, timeout=self._timeout) as response:
+            response.raise_for_status()
+            for line in response.iter_lines(decode_unicode=True):
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    LOGGER.warning("Skipping malformed JSONL line from DXR: %s", line)
+
+
+def _safe_str(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _safe_upper(value: object) -> Optional[str]:
+    text = _safe_str(value)
+    return text.upper() if text else None
+
+
+__all__ = ["Classification", "DXRClient"]

--- a/atlan-dxr-integration/atlan_dxr_integration/pipeline.py
+++ b/atlan-dxr-integration/atlan_dxr_integration/pipeline.py
@@ -1,0 +1,44 @@
+"""Orchestration for the DXR → Atlan integration."""
+
+from __future__ import annotations
+
+import logging
+
+from .atlan_uploader import AtlanUploader
+from .config import Config
+from .dataset_builder import DatasetBuilder
+from .dxr_client import DXRClient
+
+LOGGER = logging.getLogger(__name__)
+
+
+def run() -> None:
+    """Entry point for running the integration once."""
+
+    config = Config.from_env()
+    logging.basicConfig(level=config.log_level.upper())
+    LOGGER.info("Starting DXR → Atlan sync")
+
+    with DXRClient(config.dxr_base_url, config.dxr_pat) as dxr_client:
+        classifications = dxr_client.fetch_classifications()
+        builder = DatasetBuilder(
+            classifications,
+            allowed_types=config.dxr_classification_types,
+            sample_file_limit=config.dxr_sample_file_limit,
+            dxr_base_url=config.dxr_base_url,
+        )
+
+        for file_payload in dxr_client.stream_files():
+            builder.consume_file(file_payload)
+
+    records = builder.build()
+    if not records:
+        LOGGER.warning("No dataset records generated; nothing to upsert.")
+        return
+
+    uploader = AtlanUploader(config)
+    uploader.upsert(records)
+    LOGGER.info("DXR → Atlan sync completed")
+
+
+__all__ = ["run"]

--- a/atlan-dxr-integration/requirements.txt
+++ b/atlan-dxr-integration/requirements.txt
@@ -1,0 +1,3 @@
+pyatlan==8.1.0
+python-dotenv>=1.0.1,<2.0.0
+requests>=2.32.3,<3.0.0

--- a/atlan-dxr-integration/tests/test_dataset_builder.py
+++ b/atlan-dxr-integration/tests/test_dataset_builder.py
@@ -1,0 +1,69 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from atlan_dxr_integration.dataset_builder import DatasetBuilder, SampleFile
+from atlan_dxr_integration.dxr_client import Classification
+
+
+def _classification(**overrides):
+    data = {
+        "id": "123",
+        "name": "Heart Failure",
+        "type": "ANNOTATOR",
+        "subtype": "REGEX",
+        "description": "Files classified under the disease Heart Failure",
+        "link": "/resource/123",
+        "searchLink": "/resource-search/123",
+    }
+    data.update(overrides)
+    return Classification.from_dict(data)
+
+
+def test_dataset_builder_aggregates_files_and_samples():
+    classification = _classification()
+    builder = DatasetBuilder([classification], dxr_base_url="https://atlan.dataxray.io/api")
+
+    file_payload = {
+        "id": "file-1",
+        "name": "patient_data.csv",
+        "path": "/clinical/patient_data.csv",
+        "link": "/resource/file-1",
+        "labels": [{"id": "123"}],
+    }
+    builder.consume_file(file_payload)
+
+    records = builder.build()
+    assert len(records) == 1
+    record = records[0]
+
+    assert record.file_count == 1
+    assert record.source_url == "https://atlan.dataxray.io/resource-search/123"
+    assert record.description is not None
+    assert "1 file" in record.description
+    assert record.sample_files[0].render() == "patient_data.csv – /clinical/patient_data.csv"
+
+
+def test_dataset_builder_filters_types():
+    classification = _classification(type="ANNOTATOR")
+    builder = DatasetBuilder([classification], allowed_types=["LABEL"])
+    records = builder.build()
+    assert records == []
+
+
+def test_dataset_builder_handles_multiple_labels():
+    classification = _classification(id="321", name="Cardiology")
+    builder = DatasetBuilder([classification], sample_file_limit=1)
+    file_payload = {
+        "id": "file-2",
+        "filename": "report.pdf",
+        "filepath": "/reports/report.pdf",
+        "classifications": ["321", {"classificationId": "321"}],
+    }
+    builder.consume_file(file_payload)
+    records = builder.build()
+    record = records[0]
+    assert record.file_count == 2
+    assert len(record.sample_files) == 1
+    assert isinstance(record.sample_files[0], SampleFile)

--- a/atlan-dxr-integration/tests/test_pipeline_integration.py
+++ b/atlan-dxr-integration/tests/test_pipeline_integration.py
@@ -1,0 +1,162 @@
+"""Integration-style tests for the DXR → Atlan pipeline."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Iterable, Iterator, List
+
+import pytest
+
+from atlan_dxr_integration import atlan_uploader, pipeline
+from atlan_dxr_integration.dxr_client import Classification
+
+
+class _FakeDXRClient:
+    """Stub DXR client for pipeline integration tests."""
+
+    def __init__(self, classifications: Iterable[Classification], files: Iterable[dict]):
+        self._classifications = list(classifications)
+        self._files = list(files)
+
+    def __enter__(self) -> "_FakeDXRClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - cleanup hook
+        return None
+
+    def close(self) -> None:  # pragma: no cover - compatibility shim
+        return None
+
+    def fetch_classifications(self) -> List[Classification]:
+        return list(self._classifications)
+
+    def stream_files(self) -> Iterator[dict]:
+        yield from self._files
+
+
+@pytest.mark.integration
+def test_pipeline_runs_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pipeline builds datasets from DXR metadata and upserts them into Atlan."""
+
+    classifications = [
+        Classification(
+            identifier="classification-123",
+            name="Heart Failure",
+            type="ANNOTATOR",
+            subtype="REGEX",
+            description="Files classified under the disease Heart Failure",
+            link="/resource/classification-123",
+            search_link="/resource-search/classification-123",
+        )
+    ]
+    files = [
+        {
+            "id": "file-1",
+            "name": "patient-data.csv",
+            "path": "s3://bucket/patient-data.csv",
+            "labels": [{"id": "classification-123"}],
+        },
+        {
+            "id": "file-2",
+            "filename": "lab-results.parquet",
+            "filepath": "s3://bucket/lab-results.parquet",
+            "labels": [{"classificationId": "classification-123"}],
+        },
+    ]
+
+    fake_client = _FakeDXRClient(classifications, files)
+
+    def _client_factory(base_url: str, pat_token: str) -> _FakeDXRClient:
+        assert base_url == "https://dxr.example.com/api"
+        assert pat_token == "dxr-token"
+        return fake_client
+
+    monkeypatch.setenv("DXR_BASE_URL", "https://dxr.example.com/api")
+    monkeypatch.setenv("DXR_PAT", "dxr-token")
+    monkeypatch.setenv("DXR_CLASSIFICATION_TYPES", "ANNOTATOR")
+    monkeypatch.setenv("DXR_SAMPLE_FILE_LIMIT", "2")
+
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://atlan.example.com")
+    monkeypatch.setenv("ATLAN_API_TOKEN", "atlan-token")
+    monkeypatch.setenv("ATLAN_CONNECTION_QUALIFIED_NAME", "default/connection")
+    monkeypatch.setenv("ATLAN_CONNECTION_NAME", "dxr-connection")
+    monkeypatch.setenv("ATLAN_CONNECTOR_NAME", "custom-connector")
+    monkeypatch.setenv("ATLAN_DATASET_PATH_PREFIX", "dxr")
+    monkeypatch.setenv("ATLAN_BATCH_SIZE", "5")
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+
+    monkeypatch.setattr(pipeline, "DXRClient", lambda base_url, pat: _client_factory(base_url, pat))
+
+    captured_batches: list = []
+
+    class _FakeAssetClient:
+        def save(self, assets):
+            captured_batches.append(list(assets))
+            return SimpleNamespace(request_id="req-1")
+
+    class _FakeAtlanClient:
+        def __init__(self, *args, **kwargs):
+            self.asset = _FakeAssetClient()
+
+    monkeypatch.setattr(atlan_uploader, "AtlanClient", _FakeAtlanClient)
+
+    pipeline.run()
+
+    assert captured_batches, "Expected datasets to be pushed into Atlan"
+    assert len(captured_batches[0]) == 1
+    dataset = captured_batches[0][0]
+    attrs = dataset.attributes
+    assert attrs.qualified_name == "default/connection/dxr/classification-123"
+    assert attrs.name == "Heart Failure"
+    assert attrs.description == "Files classified under the disease Heart Failure"
+    assert "DXR dataset contains 2 file(s)." in attrs.user_description
+    assert "patient-data.csv" in attrs.user_description
+    assert "lab-results.parquet" in attrs.user_description
+    assert attrs.source_url == "https://dxr.example.com/resource-search/classification-123"
+
+
+@pytest.mark.integration
+def test_pipeline_skips_upload_when_no_records(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No upload is attempted if no dataset records are generated."""
+
+    classifications = [
+        Classification(
+            identifier="classification-456",
+            name="Cardiology",
+            type="ANNOTATOR",
+            subtype=None,
+            description=None,
+            link=None,
+            search_link=None,
+        )
+    ]
+
+    fake_client = _FakeDXRClient(classifications, files=[])
+
+    monkeypatch.setenv("DXR_BASE_URL", "https://dxr.example.com/api")
+    monkeypatch.setenv("DXR_PAT", "dxr-token")
+    monkeypatch.setenv("DXR_CLASSIFICATION_TYPES", "NON_MATCHING_TYPE")
+
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://atlan.example.com")
+    monkeypatch.setenv("ATLAN_API_TOKEN", "atlan-token")
+    monkeypatch.setenv("ATLAN_CONNECTION_QUALIFIED_NAME", "default/connection")
+    monkeypatch.setenv("ATLAN_CONNECTION_NAME", "dxr-connection")
+    monkeypatch.setenv("ATLAN_CONNECTOR_NAME", "custom-connector")
+
+    monkeypatch.setattr(pipeline, "DXRClient", lambda *args, **kwargs: fake_client)
+
+    uploader_called = False
+
+    class _FakeUploader:
+        def __init__(self, config):
+            pass
+
+        def upsert(self, records):  # pragma: no cover - should not be invoked
+            nonlocal uploader_called
+            uploader_called = True
+
+    monkeypatch.setattr(pipeline, "AtlanUploader", _FakeUploader)
+
+    pipeline.run()
+
+    assert uploader_called is False


### PR DESCRIPTION
## Summary
- add the atlan-dxr-integration playbook to the repository overview in AGENTS.md
- document the pytest command for the Atlan ↔ DXR integration alongside other test entrypoints

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_b_68d0308c5be48326a2655a92864ae2c3