### PR TITLE
feat: BI dashboards from DXR metadata (Power BI playbook)

### DIFF
--- a/bi-csv-export/.env.example
+++ b/bi-csv-export/.env.example
@@ -1,0 +1,46 @@
+# Copy this file to .env and fill in your values.
+# Never commit your actual .env file.
+
+# Data X-Ray tenant URL (required)
+DXR_BASE_URL=https://your-dxr-instance.example.com
+
+# Personal Access Token (required)
+DXR_BEARER_TOKEN=your-pat-token-here
+
+# Output directory for CSV files (default: ./output)
+DXR_OUTPUT_DIR=./output
+
+# Optional KQL filter -- leave blank to export all files
+# Examples:
+#   datasource.id:123
+#   labels.name:CONFIDENTIAL
+#   datasource.name:"SharePoint Production" AND labels.name:PII
+DXR_QUERY=
+
+# Set to 1 to disable TLS verification (dev/private installs only)
+DXR_NO_VERIFY_SSL=0
+
+# HTTP connection timeout in seconds (default: 120)
+DXR_HTTP_TIMEOUT=120
+
+# Cap the number of records streamed -- useful for testing (0 = no cap)
+DXR_RECORD_CAP=0
+
+# -- Power BI (scripts/publish_to_powerbi.py) ---------------------------------
+
+# Azure AD tenant ID (Azure Portal > Azure Active Directory > Overview)
+POWERBI_TENANT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+# Azure AD app registration client ID
+# Requires Power BI "Dataset.ReadWrite.All" delegated permission
+POWERBI_CLIENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+# Power BI workspace (group) ID -- from the URL: app.powerbi.com/groups/<ID>/...
+POWERBI_WORKSPACE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+# Dataset display name in Power BI Service
+POWERBI_DATASET_NAME=DXR Metadata
+
+# Service-principal client secret -- leave blank to use interactive device-code flow
+# When set, authentication is non-interactive (suitable for CI / scheduled runs)
+POWERBI_CLIENT_SECRET=

--- a/bi-csv-export/pyproject.toml
+++ b/bi-csv-export/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=70", "wheel"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "dxr-to-csv"
+version = "0.1.0"
+description = "Export Data X-Ray /api/v1/files metadata to analysis-ready CSV tables"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+dependencies = [
+    "requests>=2.31",
+]
+
+[project.optional-dependencies]
+powerbi = [
+    "msal>=1.28",
+]
+dev = [
+    "pytest>=8",
+    "pytest-mock>=3",
+]
+
+[project.scripts]
+dxr-to-csv = "dxr_to_csv.__main__:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "unit: fast, no network",
+    "integration: requires a live DXR instance",
+]

--- a/bi-csv-export/scripts/publish_to_powerbi.py
+++ b/bi-csv-export/scripts/publish_to_powerbi.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Push Data X-Ray file metadata into a Power BI Push Dataset.
+
+This script streams metadata from the DXR /api/v1/files endpoint, splits
+it into five analysis-ready tables, and pushes them into a Power BI workspace
+using the Push Datasets API.  Authentication uses MSAL device-code flow
+(browser-based, interactive) or client-credentials (service principal).
+
+Usage
+-----
+    # Interactive sign-in (device code):
+    python publish_to_powerbi.py
+
+    # Using environment variables (CI / service principal):
+    POWERBI_CLIENT_SECRET=... python publish_to_powerbi.py --non-interactive
+
+    # Filter to a specific datasource:
+    python publish_to_powerbi.py --query "datasource.id:42"
+
+Required environment variables (or pass as flags):
+    DXR_BASE_URL          - Data X-Ray tenant URL
+    DXR_BEARER_TOKEN      - DXR personal access token
+    POWERBI_TENANT_ID     - Azure AD tenant ID
+    POWERBI_CLIENT_ID     - Azure AD app registration client ID
+    POWERBI_WORKSPACE_ID  - Power BI workspace (group) GUID
+
+Optional:
+    POWERBI_CLIENT_SECRET - Service-principal secret (skips device-code)
+    POWERBI_DATASET_NAME  - Dataset display name (default: "DXR Metadata")
+    DXR_QUERY             - KQL filter applied to the /files stream
+    DXR_RECORD_CAP        - Max records to export (0 = no cap)
+    DXR_NO_VERIFY_SSL     - Set to 1 to disable TLS verification
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path setup -- allow running directly without installing the package
+# ---------------------------------------------------------------------------
+_HERE = Path(__file__).resolve().parent
+_SRC = _HERE.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from dxr_to_csv.client import DataXRayClient          # noqa: E402
+from dxr_to_csv.powerbi_client import PowerBIClient   # noqa: E402
+from dxr_to_csv.splitter import Splitter              # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)-8s  %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Stream DXR file metadata and push to a Power BI Push Dataset.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    # DXR connection
+    dxr = p.add_argument_group("Data X-Ray")
+    dxr.add_argument("--url", default=os.environ.get("DXR_BASE_URL"), metavar="URL",
+                     help="DXR tenant URL  [env: DXR_BASE_URL]")
+    dxr.add_argument("--token", default=os.environ.get("DXR_BEARER_TOKEN"), metavar="TOKEN",
+                     help="DXR bearer token  [env: DXR_BEARER_TOKEN]")
+    dxr.add_argument("--query", default=os.environ.get("DXR_QUERY", ""), metavar="KQL",
+                     help="KQL filter for /api/v1/files  [env: DXR_QUERY]")
+    dxr.add_argument("--record-cap", type=int,
+                     default=int(os.environ.get("DXR_RECORD_CAP", "0")), metavar="N",
+                     help="Stop after N records (0 = no cap)  [env: DXR_RECORD_CAP]")
+    dxr.add_argument("--no-verify-ssl", action="store_true",
+                     default=bool(int(os.environ.get("DXR_NO_VERIFY_SSL", "0"))),
+                     help="Disable TLS verification  [env: DXR_NO_VERIFY_SSL=1]")
+
+    # Power BI connection
+    pbi = p.add_argument_group("Power BI")
+    pbi.add_argument("--tenant-id", default=os.environ.get("POWERBI_TENANT_ID"),
+                     help="Azure AD tenant ID  [env: POWERBI_TENANT_ID]")
+    pbi.add_argument("--client-id", default=os.environ.get("POWERBI_CLIENT_ID"),
+                     help="Azure AD app client ID  [env: POWERBI_CLIENT_ID]")
+    pbi.add_argument("--workspace-id", default=os.environ.get("POWERBI_WORKSPACE_ID"),
+                     help="Power BI workspace GUID  [env: POWERBI_WORKSPACE_ID]")
+    pbi.add_argument("--client-secret", default=os.environ.get("POWERBI_CLIENT_SECRET"),
+                     help="Service-principal secret (non-interactive)  [env: POWERBI_CLIENT_SECRET]")
+    pbi.add_argument("--dataset-name",
+                     default=os.environ.get("POWERBI_DATASET_NAME", "DXR Metadata"),
+                     help='Dataset display name  [env: POWERBI_DATASET_NAME]  (default: "DXR Metadata")')
+    pbi.add_argument("--no-clear", action="store_true",
+                     help="Append rows instead of clearing tables before pushing")
+
+    p.add_argument("--debug", action="store_true", help="Enable debug logging")
+    return p
+
+
+def _validate(args: argparse.Namespace) -> list[str]:
+    """Return a list of validation error messages (empty = OK)."""
+    errors = []
+    if not args.url:
+        errors.append("DXR URL is required (--url or DXR_BASE_URL)")
+    if not args.token:
+        errors.append("DXR bearer token is required (--token or DXR_BEARER_TOKEN)")
+    if not args.tenant_id:
+        errors.append("Azure AD tenant ID is required (--tenant-id or POWERBI_TENANT_ID)")
+    if not args.client_id:
+        errors.append("Azure AD client ID is required (--client-id or POWERBI_CLIENT_ID)")
+    if not args.workspace_id:
+        errors.append("Power BI workspace ID is required (--workspace-id or POWERBI_WORKSPACE_ID)")
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Main logic
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    errors = _validate(args)
+    if errors:
+        for e in errors:
+            print(f"  x  {e}", file=sys.stderr)
+        parser.print_usage(sys.stderr)
+        sys.exit(1)
+
+    # ------------------------------------------------------------------
+    # 1. Authenticate with Power BI
+    # ------------------------------------------------------------------
+    print("\n--- Power BI Authentication -------------------------------------")
+    pbi = PowerBIClient(
+        tenant_id=args.tenant_id,
+        client_id=args.client_id,
+        workspace_id=args.workspace_id,
+        client_secret=args.client_secret or None,
+    )
+    pbi.authenticate()
+    print("*  Authenticated")
+
+    # ------------------------------------------------------------------
+    # 2. Resolve / create the Push Dataset
+    # ------------------------------------------------------------------
+    print(f"\n--- Dataset: {args.dataset_name!r} ------------------------------")
+    dataset_id = pbi.get_or_create_dataset(args.dataset_name)
+    print(f"*  Dataset ID: {dataset_id}")
+
+    # ------------------------------------------------------------------
+    # 3. Stream DXR metadata and split into tables
+    # ------------------------------------------------------------------
+    print("\n--- Streaming from Data X-Ray ------------------------------------")
+    dxr = DataXRayClient(
+        base_url=args.url,
+        bearer_token=args.token,
+        verify_ssl=not args.no_verify_ssl,
+    )
+
+    splitter = Splitter()
+    record_count = 0
+    t0 = time.perf_counter()
+
+    cap = args.record_cap if args.record_cap > 0 else None
+    query = args.query.strip() or None
+
+    for record in dxr.stream_files(query=query, record_cap=cap):
+        splitter.ingest(record)
+        record_count += 1
+        if record_count % 1_000 == 0:
+            elapsed = time.perf_counter() - t0
+            print(f"  ... {record_count:,} records in {elapsed:.1f}s", end="\r", flush=True)
+
+    elapsed = time.perf_counter() - t0
+    print(f"*  Streamed {record_count:,]} file records in {elapsed:.1f}s          ")
+
+    tables = splitter.tables()
+
+    # ------------------------------------------------------------------
+    # 4. Push each table to Power BI
+    # ------------------------------------------------------------------
+    print(f"\n--- Pushing to Power BI  (clear_first={not args.no_clear}) -----------")
+    total_rows = 0
+    table_order = ["files", "labels", "annotations", "extracted_metadata", "dlp_labels"]
+
+    for table_name in table_order:
+        rows = tables.get(table_name, [])
+        pushed = pbi.push_rows(
+            dataset_id,
+            table_name,
+            rows,
+            clear_first=not args.no_clear,
+        )
+        total_rows += pushed
+        status = f"{pushed:>8,,} rows"
+        print(f"  {table_name:<25}  {status}")
+
+    elapsed_total = time.perf_counter() - t0
+    print(f"\n*  Done -- {total_rows:,} total rows pushed in {elapsed_total:.1f}s")
+    print(f"\n   Open Power BI Service: https://app.powerbi.com/groups/{args.workspace_id}/datasets")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/bi-csv-export/src/dxr_to_csv/powerbi_client.py
+++ b/bi-csv-export/src/dxr_to_csv/powerbi_client.py
@@ -1,0 +1,361 @@
+"""Power BI Push Datasets client.
+
+Authenticates via MSAL device-code flow (interactive) or client-credentials
+(service principal) and pushes rows into a Power BI Push Dataset.
+
+Typical flow:
+
+    client = PowerBIClient(tenant_id, client_id, workspace_id)
+    client.authenticate()           # opens browser / prints device code
+
+    dataset_id = client.get_or_create_dataset("DXR Metadata")
+    client.clear_table(dataset_id, "files")
+    client.push_rows(dataset_id, "files", rows)     # list[dict]
+    ...
+
+Dependencies:
+    pip install msal requests
+
+Power BI REST API reference:
+    https://learn.microsoft.com/en-us/rest/api/power-bi/
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Iterator, Sequence
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_PBI_API = "https://api.powerbi.com/v1.0/myorg"
+_PBI_SCOPE = ["https://analysis.windows.net/powerbi/api/Dataset.ReadWrite.All"]
+_PUSH_BATCH = 9_000  # Power BI max is 10 000 rows per call; stay under
+
+# ---------------------------------------------------------------------------
+# Dataset schema
+# ---------------------------------------------------------------------------
+
+#: Minimal column definitions keyed by table name.  Power BI supports
+#: Int64, Double, Boolean, Datetime, String for Push Datasets.
+TABLEBSCHEMAS: dict[str, list[dict]] = {
+    "files": [
+        {"name": "file_id", "dataType": "String"},
+        {"name": "file_name", "dataType": "String"},
+        {"name": "path", "dataType": "String"},
+        {"name": "size_bytes", "dataType": "Int64"},
+        {"name": "mime_type", "dataType": "String"},
+        {"name": "created_at", "dataType": "Datetime"},
+        {"name": "modified_at", "dataType": "Datetime"},
+        {"name": "datasource_id", "dataType": "Int64"},
+        {"name": "datasource_name", "dataType": "String"},
+        {"name": "owner_email", "dataType": "String"},
+        {"name": "label_count", "dataType": "Int64"},
+        {"name": "annotation_count", "dataType": "Int64"},
+    ],
+    "labels": [
+        {"name": "file_id", "dataType": "String"},
+        {"name": "label_id", "dataType": "Int64"},
+        {"name": "label_name", "dataType": "String"},
+        {"name": "label_hex_color", "dataType": "String"},
+        {"name": "label_type", "dataType": "String"},
+    ],
+    "annotations": [
+        {"name": "file_id", "dataType": "String"},
+        {"name": "annotator_id", "dataType": "Int64"},
+        {"name": "annotator_name", "dataType": "String"},
+        {"name": "value", "dataType": "String"},
+        {"name": "start", "dataType": "Int64"},
+        {"name": "end", "dataType": "Int64"},
+    ],
+    "extracted_metadata": [
+        {"name": "file_id", "dataType": "String"},
+        {"name": "extractor_id", "dataType": "Int64"},
+        {"name": "extractor_name", "dataType": "String"},
+        {"name": "field_name", "dataType": "String"},
+        {"name": "value", "dataType": "String"},
+        {"name": "data_type", "dataType": "String"},
+    ],
+    "dlp_labels": [
+        {"name": "file_id", "dataType": "String"},
+        {"name": "dlp_label", "dataType": "String"},
+        {"name": "score", "dataType": "Double"},
+        {"name": "category", "dataType": "String"},
+    ],
+}
+
+#: Relationships that Power BI will create between the five tables.
+RELATIONSHIPS: list[dict] = [
+    {
+        "name": "files_labels",
+        "fromTable": "labels",
+        "fromColumn": "file_id",
+        "toTable": "files",
+        "toColumn": "file_id",
+        "crossFilteringBehavior": "oneDirection",
+    },
+    {
+        "name": "files_annotations",
+        "fromTable": "annotations",
+        "fromColumn": "file_id",
+        "toTable": "files",
+        "toColumn": "file_id",
+        "crossFilteringBehavior": "oneDirection",
+    },
+    {
+        "name": "files_extracted_metadata",
+        "fromTable": "extracted_metadata",
+        "fromColumn": "file_id",
+        "toTable": "files",
+        "toColumn": "file_id",
+        "crossFilteringBehavior": "oneDirection",
+    },
+    {
+        "name": "files_dlp_labels",
+        "fromTable": "dlp_labels",
+        "fromColumn": "file_id",
+        "toTable": "files",
+        "toColumn": "file_id",
+        "crossFilteringBehavior": "oneDirection",
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+class PowerBIClient:
+    """Thin wrapper around the Power BI REST API for Push Datasets.
+
+    Supports two authentication modes:
+
+    * **Device code** (default) -- interactive sign-in printed to stdout.
+      Suitable for ad-hoc exports and first-time runs.
+    * **Client credentials** -- non-interactive, for scheduled / CI use.
+      Requires ``client_secret`` to be set.
+
+    Args:
+        tenant_id:     Azure AD tenant ID.
+        client_id:     Azure AD app registration client ID.
+        workspace_id:  Power BI workspace (group) ID where the dataset lives.
+        client_secret: Service-principal secret for client-credentials flow.
+                       Leave ``None`` to use device-code authentication.
+    """
+
+    def __init__(
+        self,
+        tenant_id: str,
+        client_id: str,
+        workspace_id: str,
+        client_secret: str | None = None,
+    ) -> None:
+        self.tenant_id = tenant_id
+        self.client_id = client_id
+        self.workspace_id = workspace_id
+        self.client_secret = client_secret
+        self._access_token: str | None = None
+
+    # ------------------------------------------------------------------
+    # Authentication
+    # ------------------------------------------------------------------
+
+    def authenticate(self) -> None:
+        """Acquire an access token.
+
+        Uses device-code flow when ``client_secret`` is ``None``, otherwise
+        uses client-credentials flow (service principal).
+        """
+        try:
+            import msal  # type: ignore[import]
+        except ImportError as exc:
+            raise ImportError(
+                "msal is required for Power BI publishing.  "
+                "Install it with: pip install msal"
+            ) from exc
+
+        authority = f"https://login.microsoftonline.com/{self.tenant_id}"
+
+        if self.client_secret:
+            app = msal.ConfidentialClientApplication(
+                self.client_id,
+                authority=authority,
+                client_credential=self.client_secret,
+            )
+            result = app.acquire_token_for_client(scopes=_PBI_SCOPE)
+        else:
+            app = msal.PublicClientApplication(
+                self.client_id,
+                authority=authority,
+            )
+            # Try silent acquisition first (cached token)
+            accounts = app.get_accounts()
+            result = None
+            if accounts:
+                result = app.acquire_token_silent(_PBI_SCOPE, account=accounts[0])
+
+            if not result:
+                flow = app.initiate_device_flow(scopes=_PBI_SCOPE)
+                if "user_code" not in flow:
+                    raise RuntimeError(f"Failed to initiate device flow: {flow}")
+                print(flow["message"])  # noqa: T201  -- must be visible to user
+                result = app.acquire_token_by_device_flow(flow)
+
+        if "access_token" not in result:
+            error = result.get("error_description") or result.get("error")
+            raise RuntimeError(f"Authentication failed: {error}")
+
+        self._access_token = result["access_token"]
+        logger.info("Power BI authentication successful")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _headers(self) -> dict[str, str]:
+        if not self._access_token:
+            raise RuntimeError(
+                "Not authenticated -- call client.authenticate() first"
+            )
+        return {
+            "Authorization": f"Bearer {self._access_token}",
+            "Content-Type": "application/json",
+        }
+
+    def _url(self, path: str) -> str:
+        return f"{_PBI_API}/groups/{self.workspace_id}/{path.lstrip('/')}"
+
+    def _get(self, path: str) -> dict:
+        r = requests.get(self._url(path), headers=self._headers(), timeout=60)
+        r.raise_for_status()
+        return r.json()
+
+    def _post(self, path: str, body: dict) -> dict:
+        r = requests.post(
+            self._url(path), headers=self._headers(), json=body, timeout=60
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def _delete(self, path: str) -> None:
+        r = requests.delete(self._url(path), headers=self._headers(), timeout=60)
+        r.raise_for_status()
+
+    # ------------------------------------------------------------------
+    # Dataset management
+    # ------------------------------------------------------------------
+
+    def list_datasets(self) -> list[dict]:
+        """Return all datasets in the workspace."""
+        return self._get("datasets").get("value", [])
+
+    def get_or_create_dataset(
+        self,
+        dataset_name: str,
+        *,
+        default_mode: str = "Push",
+    ) -> str:
+        """Return the dataset ID, creating the dataset if it doesn't exist.
+
+        Args:
+            dataset_name:  Display name for the dataset in the workspace.
+            default_mode:  Typically ``"Push"`` (real-time streaming).
+
+        Returns:
+            The Power BI dataset ID (GUID string).
+        """
+        for ds in self.list_datasets():
+            if ds.get("name") == dataset_name:
+                logger.info("Using existing dataset '%s' (%s)", dataset_name, ds["id"])
+                return ds["id"]
+
+        logger.info("Creating dataset '%s' in workspace %s", dataset_name, self.workspace_id)
+        body = {
+            "name": dataset_name,
+            "defaultMode": default_mode,
+            "tables": [
+                {"name": name, "columns": cols}
+                for name, cols in TABLE_SCHEMAS.items()
+            ],
+            "relationships": RELATIONSHIPS,
+        }
+        result = self._post("datasets", body)
+        dataset_id: str = result["id"]
+        logger.info("Created dataset '%s' (%s)", dataset_name, dataset_id)
+        return dataset_id
+
+    # ------------------------------------------------------------------
+    # Row operations
+    # ------------------------------------------------------------------
+
+    def clear_table(self, dataset_id: str, table_name: str) -> None:
+        """Delete all rows in a Push Dataset table (pre-push refresh).
+
+        Args:
+            dataset_id:  Dataset GUID.
+            table_name:  One of the five table names (e.g. ``"files"``).
+        """
+        logger.debug("Clearing table '%s' in dataset %s", table_name, dataset_id)
+        try:
+            self._delete(f"datasets/{dataset_id}/tables/{table_name}/rows")
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 400:
+                # Table may have no rows -- not an error
+                logger.debug("Clear returned 400 (table may be empty) -- continuing")
+            else:
+                raise
+
+    def push_rows(
+        self,
+        dataset_id: str,
+        table_name: str,
+        rows: Sequence[dict],
+        *,
+        clear_first: bool = False,
+    ) -> int:
+        """Push rows into a Power BI Push Dataset table in batches.
+
+        Args:
+            dataset_id:   Dataset GUID.
+            table_name:   Target table name.
+            rows:         List of row dicts -- keys must match column names.
+            clear_first:  If ``True``, delete existing rows before pushing.
+
+        Returns:
+            Total number of rows pushed.
+        """
+        if clear_first:
+            self.clear_table(dataset_id, table_name)
+
+        if not rows:
+            logger.info("No rows for table '%s' -- skipping", table_name)
+            return 0
+
+        total = 0
+        for batch in _batched(rows, _PUSH_BATCH):
+            self._post(
+                f"datasets/{dataset_id}/tables/{table_name}/rows",
+                {"rows": list(batch)},
+            )
+            total += len(batch)
+            logger.debug("  pushed %d rows to '%s' (running total: %d)", len(batch), table_name, total)
+            # Brief pause to avoid hitting the 120 requests/min rate limit
+            if total < len(rows):
+                time.sleep(0.3)
+
+        logger.info("Pushed %d rows to table '%s'", total, table_name)
+        return total
+
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+
+def _batched(items: Sequence, size: int) -> Iterator[Sequence]:
+    """Yield successive fixed-size slices from ``items``."""
+    for start in range(0, len(items), size):
+        yield items[start : start + size]


### PR DESCRIPTION
Adds a complete playbook for connecting DXR metadata to Power BI governance dashboards.

## Changes

- `src/dxr_to_csv/powerbi_client.py` — Power BI Push Datasets REST API client with device-code and client-credentials auth
- `scripts/publish_to_powerbi.py` — CLI script: stream DXR `/api/v1/files` → split into 5 tables → push to Power BI
- `pyproject.toml` — adds `msal>=1.28` as an optional `[powerbi]` dependency
- `.env.example` — documents all required and optional Power BI environment variables

## Outcome

Users can run `python scripts/publish_to_powerbi.py` to push a live Push Dataset into their Power BI workspace — no ETL pipeline or data warehouse required. The dataset ships with five pre-joined tables (files, labels, annotations, extracted_metadata, dlp_labels) and pre-built relationships ready for dashboard authoring.